### PR TITLE
#121 Avoid NPE for transitions launched from a Capella model without

### DIFF
--- a/plugins/org.polarsys.capella.transition.system2subsystem.ui/src/org/polarsys/capella/transition/system2subsystem/ui/preferences/FilteredOutputModelRenderer.java
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.ui/src/org/polarsys/capella/transition/system2subsystem/ui/preferences/FilteredOutputModelRenderer.java
@@ -1,4 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2024 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
 package org.polarsys.capella.transition.system2subsystem.ui.preferences;
+
+import java.util.Optional;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -19,15 +33,15 @@ public class FilteredOutputModelRenderer extends OutputModelRenderer {
   
   class NoSourceProjectViewerFilter extends ViewerFilter {
     
-    private IProject toFilterCapellaProject;
+    private Optional<IProject> toFilterCapellaProject;
     
     public NoSourceProjectViewerFilter(Resource toFilterCapellaProject) {
-       this.toFilterCapellaProject = EcoreUtil2.getFile(toFilterCapellaProject).getProject();
+      this.toFilterCapellaProject = Optional.ofNullable(EcoreUtil2.getFile(toFilterCapellaProject)).map(f -> f.getProject());
     }
     
     @Override
     public boolean select(Viewer viewer, Object parentElement, Object element) {
-      return element instanceof IResource && !this.toFilterCapellaProject.equals(element);
+    return element instanceof IResource && !(this.toFilterCapellaProject.isPresent() && this.toFilterCapellaProject.get().equals(element));
     }
   }
   


### PR DESCRIPTION
project

This can occur when the project is a Team for Capella connected project for example.